### PR TITLE
UI improvements, NPC loot bugfix, and artwork system plan

### DIFF
--- a/docs/plans/2026-03-07-artwork-design.md
+++ b/docs/plans/2026-03-07-artwork-design.md
@@ -1,0 +1,197 @@
+# Artwork System Design
+
+**Date:** 2026-03-07
+**Status:** Approved, awaiting implementation plan
+
+## Overview
+
+Add static artwork to Star Forge: card header banners for every game entity (buildings, ships, defences, research), page banners for each major panel, and planet visuals for the galaxy map and Overview panel. All images are pre-generated manually (Claude provides prompts, user generates in DALL-E 3 / Gemini) and committed as static assets. No runtime image generation.
+
+---
+
+## Art Style
+
+Old-school realistic sci-fi illustration — painted space art in the style of 1970s–80s science fiction book covers (think Chris Foss, John Berkey, classic OGame). Not photorealistic CGI. Detailed, atmospheric, dramatic lighting.
+
+**Style prefix for every prompt:**
+> "Old-school realistic sci-fi illustration, painted space art in the style of 1970s–80s science fiction book covers, dramatic lighting, highly detailed, no text, no UI elements, no watermarks"
+
+---
+
+## Asset Inventory (~62 images total)
+
+### Card Banners (per-entity, wide landscape)
+Generated at **1792×1024**, stored at **896×512 webp**.
+
+**Buildings (~15):**
+metalMine, crystalMine, deuteriumSynthesizer, solarPlant, fusionReactor, roboticsFactory, shipyard, researchLab, naniteFactory, metalStorage, crystalStorage, deuteriumTank, missileSilo, spaceDock, terraformer
+
+**Ships (~14):**
+lightFighter, heavyFighter, cruiser, battleship, battlecruiser, bomber, destroyer, deathStar, smallCargo, largeCargo, recycler, espionageProbe, solarSatellite, colonyShip
+
+**Defences (8):**
+rocketLauncher, lightLaser, heavyLaser, gaussCannon, ionCannon, plasmaTurret, smallShieldDome, largeShieldDome
+
+**Research (~16):**
+energyTechnology, laserTechnology, ionTechnology, hyperspaceTechnology, plasmaTechnology, combustionDrive, impulseDrive, hyperspaceDrive, espionageTechnology, computerTechnology, astrophysicsTechnology, intergalacticResearchNetwork, gravitonTechnology, weaponsTechnology, shieldingTechnology, armourTechnology
+
+### Page Banners (per-panel, full-width header)
+Generated at **1792×1024**, stored at **896×512 webp**.
+
+| Panel | Subject |
+|-------|---------|
+| Fleet | Formation of warships in deep space |
+| Defence | Planetary gun batteries, shield domes, fortress |
+| Buildings | Colony base landscape, industrial structures on alien terrain |
+| Research | Orbital research lab, technology and science imagery |
+| Galaxy | Deep space star field, nebulae, galaxy view |
+
+> **Future enhancement:** Page banners dynamically swap or blend based on player fleet/defence strength on the active planet. Not implemented in this phase — static only.
+
+### Planet Visuals
+Generated at **1024×1024**, stored at two sizes: **512×512** (portrait) and **128×128** (icon).
+
+**4 planet types** mapped by `maxTemperature`:
+
+| Type | Temperature Range | Visual |
+|------|------------------|--------|
+| `hot` | > 60° | Volcanic, lava flows, scorched rock |
+| `temperate` | 20–60° | Earth-like, clouds, blue-green |
+| `cold` | -20–20° | Rocky, grey, thin atmosphere |
+| `frozen` | < -20° | Ice-covered, white-blue, glacial |
+
+---
+
+## File Structure
+
+```
+public/assets/
+  buildings/
+    metalMine.webp
+    crystalMine.webp
+    … (one per building ID)
+  ships/
+    lightFighter.webp
+    … (one per ship ID)
+  defences/
+    rocketLauncher.webp
+    … (one per defence ID)
+  research/
+    energyTechnology.webp
+    … (one per research ID)
+  planets/
+    hot.webp
+    temperate.webp
+    cold.webp
+    frozen.webp
+    hot-icon.webp
+    temperate-icon.webp
+    cold-icon.webp
+    frozen-icon.webp
+  panels/
+    fleet.webp
+    defence.webp
+    buildings.webp
+    research.webp
+    galaxy.webp
+```
+
+---
+
+## Code Architecture
+
+### Asset Map (`src/data/assets.ts`)
+Central mapping of item IDs to asset paths. Panels import from here — no path strings scattered in components.
+
+```ts
+export const BUILDING_IMAGES: Record<string, string> = {
+  metalMine: '/assets/buildings/metalMine.webp',
+  crystalMine: '/assets/buildings/crystalMine.webp',
+  // …
+};
+
+export const SHIP_IMAGES: Record<string, string> = { … };
+export const DEFENCE_IMAGES: Record<string, string> = { … };
+export const RESEARCH_IMAGES: Record<string, string> = { … };
+export const PANEL_IMAGES = {
+  fleet: '/assets/panels/fleet.webp',
+  defence: '/assets/panels/defence.webp',
+  buildings: '/assets/panels/buildings.webp',
+  research: '/assets/panels/research.webp',
+  galaxy: '/assets/panels/galaxy.webp',
+} as const;
+
+export function getPlanetType(maxTemperature: number): 'hot' | 'temperate' | 'cold' | 'frozen' {
+  if (maxTemperature > 60) return 'hot';
+  if (maxTemperature > 20) return 'temperate';
+  if (maxTemperature > -20) return 'cold';
+  return 'frozen';
+}
+
+export function getPlanetImageUrl(maxTemperature: number, size: 'portrait' | 'icon' = 'portrait'): string {
+  const type = getPlanetType(maxTemperature);
+  return size === 'icon' ? `/assets/planets/${type}-icon.webp` : `/assets/planets/${type}.webp`;
+}
+```
+
+### Fallback Behavior
+If an image fails to load, show a dark gradient placeholder — no broken image icon. Implemented via `onError` handler or CSS background fallback.
+
+```tsx
+<img
+  src={src}
+  alt=""
+  className="card-banner-img"
+  onError={(e) => { e.currentTarget.style.display = 'none'; }}
+/>
+```
+
+Or wrap in a `<div className="card-banner">` with a CSS gradient background so the div shows through when the image is absent.
+
+### UI Integration
+
+**Card banners** — top of each building/ship/defence/research card:
+```css
+.card-banner-img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+  border-radius: 0.4rem 0.4rem 0 0;
+}
+```
+
+**Page banners** — full-width header at top of each panel:
+```css
+.panel-banner-img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+  margin-bottom: 1rem;
+}
+```
+
+**Planet portrait** (Overview panel): `256×256`, circular (`border-radius: 50%`)
+
+**Planet icon** (Galaxy map slot): `48×48`, circular
+
+---
+
+## Generation Workflow
+
+1. Claude provides a crafted prompt for each item (in the implementation plan)
+2. User generates in DALL-E 3 (ChatGPT) or Gemini Imagen at the specified resolution
+3. User resizes: card/panel art → 896×512; planet portrait → 512×512; planet icon → 128×128
+4. Save as `.webp` to the correct `public/assets/` subfolder
+5. Wire up in `src/data/assets.ts` (Codex handles the code; user handles the files)
+
+---
+
+## Phases
+
+- **Phase A (this plan):** All code wiring — `assets.ts`, card banner `<img>` tags, page banner components, planet visuals in Overview + Galaxy map. Placeholders (gradient divs) everywhere images would appear.
+- **Phase B (manual):** User generates and drops in actual `.webp` files. No code changes needed — images appear automatically.
+- **Phase C (future):** Dynamic page banners that reflect fleet/defence strength.

--- a/docs/plans/2026-03-07-artwork-design.md
+++ b/docs/plans/2026-03-07-artwork-design.md
@@ -1,7 +1,7 @@
 # Artwork System Design
 
 **Date:** 2026-03-07
-**Status:** Approved, awaiting implementation plan
+**Status:** Approved – implementation plan drafted
 
 ## Overview
 

--- a/docs/plans/2026-03-07-artwork-implementation.md
+++ b/docs/plans/2026-03-07-artwork-implementation.md
@@ -1,6 +1,6 @@
 # Artwork System Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Note:** This is an implementation plan intended to be followed task-by-task by contributors or automation.
 
 **Goal:** Wire up the artwork system — asset map, CSS, card banners, page banners, and planet visuals — so that dropping `.webp` files into `public/assets/` makes them appear automatically. No images are generated here; this is code-only.
 

--- a/docs/plans/2026-03-07-artwork-implementation.md
+++ b/docs/plans/2026-03-07-artwork-implementation.md
@@ -1,0 +1,966 @@
+# Artwork System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire up the artwork system — asset map, CSS, card banners, page banners, and planet visuals — so that dropping `.webp` files into `public/assets/` makes them appear automatically. No images are generated here; this is code-only.
+
+**Architecture:** Central `src/data/assets.ts` maps all item IDs to `/assets/...` paths. Panels import from there. Images are wrapped in a `<div className="card-banner">` container with a dark CSS fallback; the `<img>` uses `onError` to self-hide if the file doesn't exist yet. Planet type is derived from `maxTemperature` at render time.
+
+**Tech Stack:** React 19, TypeScript strict, Vite (serves `public/` as-is), CSS custom properties, vitest + @testing-library/react
+
+---
+
+## Key Files Reference
+
+- `src/data/assets.ts` — **create new** — central asset map
+- `src/data/buildings.ts` — BUILDING_ORDER (12 IDs)
+- `src/data/ships.ts` — SHIP_ORDER (13 IDs)
+- `src/data/defences.ts` — DEFENCE_ORDER (8 IDs)
+- `src/data/research.ts` — RESEARCH_ORDER (15 IDs)
+- `src/panels/BuildingsPanel.tsx` — card items in `<article className="item-card">`, header in `<div className="item-header">`
+- `src/panels/ShipyardPanel.tsx` — same card structure
+- `src/panels/DefencePanel.tsx` — same card structure
+- `src/panels/ResearchPanel.tsx` — same card structure
+- `src/panels/FleetPanel.tsx` — top-level `<section className="panel">`
+- `src/panels/OverviewPanel.tsx` — shows `planet.name` and `planet.maxTemperature`
+- `src/panels/GalaxyPanel.tsx` — renders `SystemSlot` rows; `slot.type === 'npc'` or `'player'`; NPC has `slot.npc?.temperature`
+- `src/styles.css` — global styles
+- `src/test/test-utils.tsx` — `renderWithGame(component, options)` for all tests
+
+---
+
+## Complete Item ID Lists
+
+**Buildings (12):** metalMine, crystalMine, deuteriumSynthesizer, solarPlant, fusionReactor, metalStorage, crystalStorage, deuteriumTank, roboticsFactory, naniteFactory, shipyard, researchLab
+
+**Ships (13):** lightFighter, heavyFighter, cruiser, battleship, bomber, destroyer, battlecruiser, smallCargo, largeCargo, colonyShip, recycler, espionageProbe, solarSatellite
+
+**Defences (8):** rocketLauncher, lightLaser, heavyLaser, gaussCannon, ionCannon, plasmaTurret, smallShieldDome, largeShieldDome
+
+**Research (15):** energyTechnology, laserTechnology, ionTechnology, plasmaTechnology, espionageTechnology, computerTechnology, weaponsTechnology, shieldingTechnology, armourTechnology, combustionDrive, impulseDrive, hyperspaceTechnology, hyperspaceDrive, astrophysicsTechnology, intergalacticResearchNetwork
+
+**Planets (4):** hot, temperate, cold, frozen
+
+**Page banners (5):** fleet, defence, buildings, research, galaxy
+
+---
+
+## Task 1: Create `src/data/assets.ts`
+
+**Files:**
+- Create: `src/data/assets.ts`
+- Test: `src/data/__tests__/assets.test.ts`
+
+### Step 1: Write the failing test
+
+Create `src/data/__tests__/assets.test.ts`:
+
+```typescript
+import { getPlanetType, getPlanetImageUrl, BUILDING_IMAGES, SHIP_IMAGES, DEFENCE_IMAGES, RESEARCH_IMAGES, PANEL_IMAGES } from '../assets';
+
+describe('getPlanetType', () => {
+  it('returns hot for temperature above 60', () => {
+    expect(getPlanetType(61)).toBe('hot');
+    expect(getPlanetType(100)).toBe('hot');
+  });
+  it('returns temperate for 20–60', () => {
+    expect(getPlanetType(60)).toBe('temperate');
+    expect(getPlanetType(21)).toBe('temperate');
+  });
+  it('returns cold for -20 to 20', () => {
+    expect(getPlanetType(20)).toBe('cold');
+    expect(getPlanetType(-19)).toBe('cold');
+  });
+  it('returns frozen for -20 and below', () => {
+    expect(getPlanetType(-20)).toBe('frozen');
+    expect(getPlanetType(-100)).toBe('frozen');
+  });
+});
+
+describe('getPlanetImageUrl', () => {
+  it('returns portrait path by default', () => {
+    expect(getPlanetImageUrl(80)).toBe('/assets/planets/hot.webp');
+  });
+  it('returns icon path when requested', () => {
+    expect(getPlanetImageUrl(0)).toBe('/assets/planets/cold-icon.webp');
+  });
+});
+
+describe('asset maps', () => {
+  it('BUILDING_IMAGES has all 12 buildings', () => {
+    expect(Object.keys(BUILDING_IMAGES)).toHaveLength(12);
+    expect(BUILDING_IMAGES.metalMine).toBe('/assets/buildings/metalMine.webp');
+  });
+  it('SHIP_IMAGES has all 13 ships', () => {
+    expect(Object.keys(SHIP_IMAGES)).toHaveLength(13);
+  });
+  it('DEFENCE_IMAGES has all 8 defences', () => {
+    expect(Object.keys(DEFENCE_IMAGES)).toHaveLength(8);
+  });
+  it('RESEARCH_IMAGES has all 15 research items', () => {
+    expect(Object.keys(RESEARCH_IMAGES)).toHaveLength(15);
+  });
+  it('PANEL_IMAGES has all 5 panels', () => {
+    expect(Object.keys(PANEL_IMAGES)).toHaveLength(5);
+    expect(PANEL_IMAGES.fleet).toBe('/assets/panels/fleet.webp');
+  });
+});
+```
+
+### Step 2: Run to verify it fails
+
+```bash
+npx vitest run src/data/__tests__/assets.test.ts
+```
+Expected: FAIL — module not found
+
+### Step 3: Create `src/data/assets.ts`
+
+```typescript
+export type PlanetType = 'hot' | 'temperate' | 'cold' | 'frozen';
+
+export function getPlanetType(maxTemperature: number): PlanetType {
+  if (maxTemperature > 60) return 'hot';
+  if (maxTemperature > 20) return 'temperate';
+  if (maxTemperature > -20) return 'cold';
+  return 'frozen';
+}
+
+export function getPlanetImageUrl(
+  maxTemperature: number,
+  size: 'portrait' | 'icon' = 'portrait',
+): string {
+  const type = getPlanetType(maxTemperature);
+  return size === 'icon'
+    ? `/assets/planets/${type}-icon.webp`
+    : `/assets/planets/${type}.webp`;
+}
+
+export const BUILDING_IMAGES: Record<string, string> = {
+  metalMine: '/assets/buildings/metalMine.webp',
+  crystalMine: '/assets/buildings/crystalMine.webp',
+  deuteriumSynthesizer: '/assets/buildings/deuteriumSynthesizer.webp',
+  solarPlant: '/assets/buildings/solarPlant.webp',
+  fusionReactor: '/assets/buildings/fusionReactor.webp',
+  metalStorage: '/assets/buildings/metalStorage.webp',
+  crystalStorage: '/assets/buildings/crystalStorage.webp',
+  deuteriumTank: '/assets/buildings/deuteriumTank.webp',
+  roboticsFactory: '/assets/buildings/roboticsFactory.webp',
+  naniteFactory: '/assets/buildings/naniteFactory.webp',
+  shipyard: '/assets/buildings/shipyard.webp',
+  researchLab: '/assets/buildings/researchLab.webp',
+};
+
+export const SHIP_IMAGES: Record<string, string> = {
+  lightFighter: '/assets/ships/lightFighter.webp',
+  heavyFighter: '/assets/ships/heavyFighter.webp',
+  cruiser: '/assets/ships/cruiser.webp',
+  battleship: '/assets/ships/battleship.webp',
+  bomber: '/assets/ships/bomber.webp',
+  destroyer: '/assets/ships/destroyer.webp',
+  battlecruiser: '/assets/ships/battlecruiser.webp',
+  smallCargo: '/assets/ships/smallCargo.webp',
+  largeCargo: '/assets/ships/largeCargo.webp',
+  colonyShip: '/assets/ships/colonyShip.webp',
+  recycler: '/assets/ships/recycler.webp',
+  espionageProbe: '/assets/ships/espionageProbe.webp',
+  solarSatellite: '/assets/ships/solarSatellite.webp',
+};
+
+export const DEFENCE_IMAGES: Record<string, string> = {
+  rocketLauncher: '/assets/defences/rocketLauncher.webp',
+  lightLaser: '/assets/defences/lightLaser.webp',
+  heavyLaser: '/assets/defences/heavyLaser.webp',
+  gaussCannon: '/assets/defences/gaussCannon.webp',
+  ionCannon: '/assets/defences/ionCannon.webp',
+  plasmaTurret: '/assets/defences/plasmaTurret.webp',
+  smallShieldDome: '/assets/defences/smallShieldDome.webp',
+  largeShieldDome: '/assets/defences/largeShieldDome.webp',
+};
+
+export const RESEARCH_IMAGES: Record<string, string> = {
+  energyTechnology: '/assets/research/energyTechnology.webp',
+  laserTechnology: '/assets/research/laserTechnology.webp',
+  ionTechnology: '/assets/research/ionTechnology.webp',
+  plasmaTechnology: '/assets/research/plasmaTechnology.webp',
+  espionageTechnology: '/assets/research/espionageTechnology.webp',
+  computerTechnology: '/assets/research/computerTechnology.webp',
+  weaponsTechnology: '/assets/research/weaponsTechnology.webp',
+  shieldingTechnology: '/assets/research/shieldingTechnology.webp',
+  armourTechnology: '/assets/research/armourTechnology.webp',
+  combustionDrive: '/assets/research/combustionDrive.webp',
+  impulseDrive: '/assets/research/impulseDrive.webp',
+  hyperspaceTechnology: '/assets/research/hyperspaceTechnology.webp',
+  hyperspaceDrive: '/assets/research/hyperspaceDrive.webp',
+  astrophysicsTechnology: '/assets/research/astrophysicsTechnology.webp',
+  intergalacticResearchNetwork: '/assets/research/intergalacticResearchNetwork.webp',
+};
+
+export const PANEL_IMAGES = {
+  fleet: '/assets/panels/fleet.webp',
+  defence: '/assets/panels/defence.webp',
+  buildings: '/assets/panels/buildings.webp',
+  research: '/assets/panels/research.webp',
+  galaxy: '/assets/panels/galaxy.webp',
+} as const;
+```
+
+### Step 4: Run to verify it passes
+
+```bash
+npx vitest run src/data/__tests__/assets.test.ts
+```
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add src/data/assets.ts src/data/__tests__/assets.test.ts
+git commit -m "feat(assets): add central asset map and planet type helpers"
+```
+
+---
+
+## Task 2: CSS — card banners, page banners, planet images
+
+**Files:**
+- Modify: `src/styles.css`
+
+No test needed for CSS. Add the following at the end of `src/styles.css`:
+
+```css
+/* ── Artwork ────────────────────────────────────── */
+
+/* Card banner — appears at top of each item card */
+.card-banner {
+  width: 100%;
+  height: 120px;
+  background: linear-gradient(135deg, #0d1117 0%, #161b22 100%);
+  border-radius: 0.4rem 0.4rem 0 0;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.card-banner img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+/* Page banner — full-width header at top of each panel */
+.panel-banner {
+  width: 100%;
+  height: 180px;
+  background: linear-gradient(135deg, #0d1117 0%, #161b22 100%);
+  border-radius: 0.4rem;
+  overflow: hidden;
+  margin-bottom: 1rem;
+  flex-shrink: 0;
+}
+
+.panel-banner img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+/* Planet portrait — Overview panel */
+.planet-portrait {
+  width: 256px;
+  height: 256px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #0d1117 0%, #1c2333 100%);
+  overflow: hidden;
+  flex-shrink: 0;
+  margin: 0 auto 1rem;
+}
+
+.planet-portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Planet icon — Galaxy map */
+.planet-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #0d1117 0%, #1c2333 100%);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.planet-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+```
+
+### Commit
+
+```bash
+git add src/styles.css
+git commit -m "feat(styles): add artwork CSS — card banners, page banners, planet visuals"
+```
+
+---
+
+## Task 3: Page banners — Fleet, Defence, Buildings, Research, Galaxy panels
+
+**Files:**
+- Modify: `src/panels/FleetPanel.tsx`, `src/panels/DefencePanel.tsx`, `src/panels/BuildingsPanel.tsx`, `src/panels/ResearchPanel.tsx`, `src/panels/GalaxyPanel.tsx`
+
+In each panel, add `import { PANEL_IMAGES } from '../data/assets.ts';` at the top (with existing imports).
+
+Then add the banner as the **first child** inside the `<section className="panel">` element:
+
+```tsx
+<div className="panel-banner">
+  <img
+    src={PANEL_IMAGES.buildings}  {/* change key per panel */}
+    alt=""
+    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+  />
+</div>
+```
+
+Use the correct key per panel:
+- BuildingsPanel → `PANEL_IMAGES.buildings`
+- DefencePanel → `PANEL_IMAGES.defence`
+- FleetPanel → `PANEL_IMAGES.fleet`
+- ResearchPanel → `PANEL_IMAGES.research`
+- GalaxyPanel → `PANEL_IMAGES.galaxy`
+
+### Smoke test
+
+```bash
+npm run build
+```
+Expected: clean build, no TypeScript errors.
+
+### Commit
+
+```bash
+git add src/panels/FleetPanel.tsx src/panels/DefencePanel.tsx src/panels/BuildingsPanel.tsx src/panels/ResearchPanel.tsx src/panels/GalaxyPanel.tsx
+git commit -m "feat(panels): add page banner image to Fleet, Defence, Buildings, Research, Galaxy panels"
+```
+
+---
+
+## Task 4: Card banners — BuildingsPanel
+
+**Files:**
+- Modify: `src/panels/BuildingsPanel.tsx`
+- Test: `src/panels/__tests__/BuildingsPanel.test.tsx`
+
+### Step 1: Write the failing test
+
+Add to `src/panels/__tests__/BuildingsPanel.test.tsx`:
+
+```tsx
+it('renders a card banner img with correct src for each building', () => {
+  renderWithGame(<BuildingsPanel />);
+
+  // Metal Mine card should have a banner img pointing to the asset path
+  const imgs = document.querySelectorAll('.card-banner img');
+  const srcs = Array.from(imgs).map((img) => (img as HTMLImageElement).src);
+  expect(srcs.some((src) => src.includes('metalMine.webp'))).toBe(true);
+});
+```
+
+### Step 2: Run to verify it fails
+
+```bash
+npx vitest run src/panels/__tests__/BuildingsPanel.test.tsx
+```
+Expected: FAIL — no `.card-banner img` elements found
+
+### Step 3: Add card banners to BuildingsPanel
+
+Add `import { BUILDING_IMAGES, SHIP_IMAGES } from '../data/assets.ts';` to `src/panels/BuildingsPanel.tsx`.
+
+Inside the building card rendering loop, add `<div className="card-banner">` as the **first child** of `<article className="item-card">`:
+
+```tsx
+<article key={buildingId} className="item-card">
+  <div className="card-banner">
+    <img
+      src={BUILDING_IMAGES[buildingId]}
+      alt=""
+      onError={(e) => { e.currentTarget.style.display = 'none'; }}
+    />
+  </div>
+  <div className="item-header">
+    {/* existing content unchanged */}
+  </div>
+  {/* rest of card unchanged */}
+</article>
+```
+
+Also add a card banner to the Solar Satellite card (which is a ship):
+```tsx
+<div className="card-banner">
+  <img
+    src={SHIP_IMAGES.solarSatellite}
+    alt=""
+    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+  />
+</div>
+```
+
+### Step 4: Run to verify it passes
+
+```bash
+npx vitest run src/panels/__tests__/BuildingsPanel.test.tsx
+```
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add src/panels/BuildingsPanel.tsx src/panels/__tests__/BuildingsPanel.test.tsx
+git commit -m "feat(buildings): add card banner images to building cards"
+```
+
+---
+
+## Task 5: Card banners — ShipyardPanel
+
+**Files:**
+- Modify: `src/panels/ShipyardPanel.tsx`
+- Test: `src/panels/__tests__/ShipyardPanel.test.tsx`
+
+### Step 1: Write the failing test
+
+Add to `src/panels/__tests__/ShipyardPanel.test.tsx`:
+
+```tsx
+it('renders card banner imgs for ship cards', () => {
+  renderWithGame(<ShipyardPanel />, {
+    gameState: { planet: { buildings: { shipyard: 1 } } },
+  });
+
+  const imgs = document.querySelectorAll('.card-banner img');
+  expect(imgs.length).toBeGreaterThan(0);
+  const srcs = Array.from(imgs).map((img) => (img as HTMLImageElement).src);
+  expect(srcs.some((src) => src.includes('lightFighter.webp'))).toBe(true);
+});
+```
+
+### Step 2: Run to verify it fails
+
+```bash
+npx vitest run src/panels/__tests__/ShipyardPanel.test.tsx
+```
+Expected: FAIL
+
+### Step 3: Add card banners to ShipyardPanel
+
+Add `import { SHIP_IMAGES } from '../data/assets.ts';` to `src/panels/ShipyardPanel.tsx`.
+
+In the ship card loop, add as first child of `<article>`:
+
+```tsx
+<div className="card-banner">
+  <img
+    src={SHIP_IMAGES[shipId]}
+    alt=""
+    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+  />
+</div>
+```
+
+### Step 4: Run to verify it passes
+
+```bash
+npx vitest run src/panels/__tests__/ShipyardPanel.test.tsx
+```
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add src/panels/ShipyardPanel.tsx src/panels/__tests__/ShipyardPanel.test.tsx
+git commit -m "feat(shipyard): add card banner images to ship cards"
+```
+
+---
+
+## Task 6: Card banners — DefencePanel
+
+**Files:**
+- Modify: `src/panels/DefencePanel.tsx`
+- Test: `src/panels/__tests__/DefencePanel.test.tsx`
+
+### Step 1: Write the failing test
+
+In `src/panels/__tests__/DefencePanel.test.tsx` (create if it doesn't exist — model on ShipyardPanel.test.tsx):
+
+```tsx
+import { screen } from '@testing-library/react';
+import { DefencePanel } from '../DefencePanel';
+import { renderWithGame } from '../../test/test-utils';
+
+describe('DefencePanel', () => {
+  it('renders card banner imgs for defence cards', () => {
+    renderWithGame(<DefencePanel />, {
+      gameState: { planet: { buildings: { shipyard: 1 } } },
+    });
+
+    const imgs = document.querySelectorAll('.card-banner img');
+    expect(imgs.length).toBeGreaterThan(0);
+    const srcs = Array.from(imgs).map((img) => (img as HTMLImageElement).src);
+    expect(srcs.some((src) => src.includes('rocketLauncher.webp'))).toBe(true);
+  });
+});
+```
+
+### Step 2: Run to verify it fails
+
+```bash
+npx vitest run src/panels/__tests__/DefencePanel.test.tsx
+```
+Expected: FAIL
+
+### Step 3: Add card banners to DefencePanel
+
+Add `import { DEFENCE_IMAGES } from '../data/assets.ts';` to `src/panels/DefencePanel.tsx`.
+
+Add as first child of each defence `<article>`:
+
+```tsx
+<div className="card-banner">
+  <img
+    src={DEFENCE_IMAGES[defenceId]}
+    alt=""
+    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+  />
+</div>
+```
+
+### Step 4: Run to verify it passes
+
+```bash
+npx vitest run src/panels/__tests__/DefencePanel.test.tsx
+```
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add src/panels/DefencePanel.tsx src/panels/__tests__/DefencePanel.test.tsx
+git commit -m "feat(defence): add card banner images to defence cards"
+```
+
+---
+
+## Task 7: Card banners — ResearchPanel
+
+**Files:**
+- Modify: `src/panels/ResearchPanel.tsx`
+- Test: `src/panels/__tests__/ResearchPanel.test.tsx`
+
+### Step 1: Write the failing test
+
+Add to `src/panels/__tests__/ResearchPanel.test.tsx`:
+
+```tsx
+it('renders card banner imgs for research cards', () => {
+  renderWithGame(<ResearchPanel />, {
+    gameState: { planet: { buildings: { researchLab: 1 } } },
+  });
+
+  const imgs = document.querySelectorAll('.card-banner img');
+  expect(imgs.length).toBeGreaterThan(0);
+  const srcs = Array.from(imgs).map((img) => (img as HTMLImageElement).src);
+  expect(srcs.some((src) => src.includes('energyTechnology.webp'))).toBe(true);
+});
+```
+
+### Step 2: Run to verify it fails
+
+```bash
+npx vitest run src/panels/__tests__/ResearchPanel.test.tsx
+```
+Expected: FAIL
+
+### Step 3: Add card banners to ResearchPanel
+
+Add `import { RESEARCH_IMAGES } from '../data/assets.ts';` to `src/panels/ResearchPanel.tsx`.
+
+Add as first child of each research `<article>`:
+
+```tsx
+<div className="card-banner">
+  <img
+    src={RESEARCH_IMAGES[researchId]}
+    alt=""
+    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+  />
+</div>
+```
+
+### Step 4: Run to verify it passes
+
+```bash
+npx vitest run src/panels/__tests__/ResearchPanel.test.tsx
+```
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add src/panels/ResearchPanel.tsx src/panels/__tests__/ResearchPanel.test.tsx
+git commit -m "feat(research): add card banner images to research cards"
+```
+
+---
+
+## Task 8: Planet portrait — OverviewPanel
+
+**Files:**
+- Modify: `src/panels/OverviewPanel.tsx`
+- Test: `src/panels/__tests__/OverviewPanel.test.tsx` (check if exists; add to it or create)
+
+### Step 1: Write the failing test
+
+Add to the Overview panel test file:
+
+```tsx
+it('renders planet portrait img with correct type src based on temperature', () => {
+  renderWithGame(<OverviewPanel />, {
+    gameState: {
+      planet: { maxTemperature: 80 }, // > 60 → hot
+    },
+  });
+
+  const portrait = document.querySelector('.planet-portrait img') as HTMLImageElement;
+  expect(portrait).toBeTruthy();
+  expect(portrait.src).toContain('hot.webp');
+});
+```
+
+### Step 2: Run to verify it fails
+
+```bash
+npx vitest run src/panels/__tests__/OverviewPanel.test.tsx
+```
+Expected: FAIL — no `.planet-portrait img` found
+
+### Step 3: Add planet portrait to OverviewPanel
+
+Add to imports in `src/panels/OverviewPanel.tsx`:
+```tsx
+import { getPlanetImageUrl } from '../data/assets.ts';
+```
+
+Find the section that shows `planet.name` and `planet.maxTemperature`. Add the planet portrait directly above the planet name:
+
+```tsx
+<div className="planet-portrait">
+  <img
+    src={getPlanetImageUrl(planet.maxTemperature)}
+    alt={planet.name}
+    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+  />
+</div>
+```
+
+### Step 4: Run to verify it passes
+
+```bash
+npx vitest run src/panels/__tests__/OverviewPanel.test.tsx
+```
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add src/panels/OverviewPanel.tsx src/panels/__tests__/OverviewPanel.test.tsx
+git commit -m "feat(overview): add planet portrait image based on temperature type"
+```
+
+---
+
+## Task 9: Planet icons — GalaxyPanel
+
+**Files:**
+- Modify: `src/panels/GalaxyPanel.tsx`
+- Test: `src/panels/__tests__/GalaxyPanel.test.tsx`
+
+Planet icons appear in the galaxy grid rows. Each NPC colony has a `temperature` field on `slot.npc`. Each player planet has `maxTemperature` on `slot.planet`.
+
+### Step 1: Write the failing test
+
+Add to `src/panels/__tests__/GalaxyPanel.test.tsx`:
+
+```tsx
+it('renders planet icon for NPC colony row', () => {
+  renderWithGame(<GalaxyPanel />, {
+    gameState: {
+      galaxy: {
+        seed: 1,
+        npcColonies: [
+          {
+            coordinates: { galaxy: 1, system: 1, slot: 3 },
+            name: 'Test Base',
+            temperature: 80, // hot
+            tier: 1,
+            specialty: 'balanced',
+            maxTier: 5,
+            initialUpgradeIntervalMs: 21_600_000,
+            currentUpgradeIntervalMs: 21_600_000,
+            targetTier: 1,
+            catchUpUpgradeIntervalMs: 5_400_000,
+            catchUpProgressTicks: 0,
+            lastUpgradeAt: 0,
+            upgradeTickCount: 0,
+            raidCount: 0,
+            recentRaidTimestamps: [],
+            abandonedAt: undefined,
+            buildings: {},
+            baseDefences: {},
+            baseShips: {},
+            currentDefences: {},
+            currentShips: {},
+            lastRaidedAt: 0,
+            resourcesAtLastRaid: { metal: 0, crystal: 0, deuterium: 0 },
+          },
+        ],
+      },
+    },
+  });
+
+  const icons = document.querySelectorAll('.planet-icon img');
+  expect(icons.length).toBeGreaterThan(0);
+  const srcs = Array.from(icons).map((img) => (img as HTMLImageElement).src);
+  expect(srcs.some((src) => src.includes('hot-icon.webp'))).toBe(true);
+});
+```
+
+### Step 2: Run to verify it fails
+
+```bash
+npx vitest run src/panels/__tests__/GalaxyPanel.test.tsx
+```
+Expected: FAIL
+
+### Step 3: Add planet icons to GalaxyPanel
+
+Add to imports in `src/panels/GalaxyPanel.tsx`:
+```tsx
+import { getPlanetImageUrl } from '../data/assets.ts';
+```
+
+In the `SystemSlotRow` component (or wherever `slot.type === 'npc'` and `slot.type === 'player'` rows are rendered), add a `<div className="planet-icon">` before the slot name text:
+
+For NPC slots (have `slot.npc.temperature`):
+```tsx
+{slot.type === 'npc' && (
+  <div className="planet-icon">
+    <img
+      src={getPlanetImageUrl(slot.npc!.temperature, 'icon')}
+      alt=""
+      onError={(e) => { e.currentTarget.style.display = 'none'; }}
+    />
+  </div>
+)}
+```
+
+For player slots (have `slot.planet.maxTemperature`):
+```tsx
+{slot.type === 'player' && (
+  <div className="planet-icon">
+    <img
+      src={getPlanetImageUrl(slot.planet!.maxTemperature, 'icon')}
+      alt=""
+      onError={(e) => { e.currentTarget.style.display = 'none'; }}
+    />
+  </div>
+)}
+```
+
+Place these icons inside the existing row structure, adjacent to the planet name text. Read the existing row JSX carefully before inserting — do not break existing layout.
+
+### Step 4: Run to verify it passes
+
+```bash
+npx vitest run src/panels/__tests__/GalaxyPanel.test.tsx
+```
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add src/panels/GalaxyPanel.tsx src/panels/__tests__/GalaxyPanel.test.tsx
+git commit -m "feat(galaxy): add planet type icons to galaxy map rows"
+```
+
+---
+
+## Task 10: Full test suite + public directory structure
+
+### Step 1: Create public/assets directory structure
+
+```bash
+mkdir -p public/assets/buildings public/assets/ships public/assets/defences public/assets/research public/assets/planets public/assets/panels
+```
+
+Create a `.gitkeep` in each so the empty dirs are tracked:
+
+```bash
+for dir in buildings ships defences research planets panels; do
+  touch public/assets/$dir/.gitkeep
+done
+```
+
+### Step 2: Run full test suite
+
+```bash
+npm test
+```
+Expected: All tests pass, no regressions.
+
+### Step 3: Commit
+
+```bash
+git add public/assets/
+git add -A
+git commit -m "feat(artwork): wire up complete artwork system — asset map, CSS, banners, planet visuals"
+```
+
+---
+
+## Task 11: Write image generation prompts
+
+Create `docs/plans/2026-03-07-artwork-prompts.md` with a complete DALL-E 3 prompt for every image. This file is the reference for the user to generate images in ChatGPT/Gemini.
+
+**Style prefix** (prepend to every prompt):
+> Old-school realistic sci-fi illustration, painted space art in the style of 1970s–80s science fiction book covers, dramatic lighting, highly detailed, no text, no logos, no watermarks
+
+**Size instructions per category:**
+- Card banners (buildings, ships, defences, research): request **1792×1024** (wide landscape)
+- Page banners: request **1792×1024**
+- Planet portraits: request **1024×1024**
+- Planet icons: same generation as portrait, resize to 128×128 during export
+
+**Write a prompt for each item below.** Save as `docs/plans/2026-03-07-artwork-prompts.md`.
+
+### Buildings
+
+| ID | Prompt Subject |
+|----|---------------|
+| metalMine | Massive open-pit metal mine on an alien planet, industrial drilling rigs, glowing ore veins, harsh lighting |
+| crystalMine | Crystal extraction facility carved into a crystalline cliff face, blue-purple crystal formations, laser cutters |
+| deuteriumSynthesizer | Deuterium processing plant beside an alien ocean, atmospheric condensers, pipes and tanks |
+| solarPlant | Solar energy farm on a sun-baked planet, enormous mirrored dishes, heat haze |
+| fusionReactor | Underground fusion reactor complex, plasma containment rings, intense blue-white glow |
+| metalStorage | Enormous metal storage silos on a barren plain, industrial scale, conveyor systems |
+| crystalStorage | Crystal warehouse with transparent walls, stacked crystal formations glowing within |
+| deuteriumTank | Pressurised deuterium storage tanks, frost-covered pipes, industrial landscape |
+| roboticsFactory | Factory floor with robotic assembly arms building spacecraft components, sparks and welding arcs |
+| naniteFactory | Gleaming nanite production facility, ultra-clean white chambers, microscale machinery visible in glowing vats |
+| shipyard | Enormous orbital shipyard in space, skeletal ship frames under construction, welding torches, stars beyond |
+| researchLab | High-tech research laboratory, holographic displays, scientists at work, alien technology samples |
+
+### Ships
+
+| ID | Prompt Subject |
+|----|---------------|
+| lightFighter | Sleek single-seat space fighter, delta-wing design, engine trails, deep space background |
+| heavyFighter | Heavier armoured fighter with twin cannons, scarred hull, battle-worn, asteroid field |
+| cruiser | Mid-size warship cruising through space, rotating gun turrets, running lights, nebula backdrop |
+| battleship | Massive battleship dwarfing smaller craft, heavy armour plating, multiple gun batteries |
+| bomber | Wide-bodied space bomber with torpedo bays open, menacing silhouette, approaching a planet |
+| destroyer | Long sleek destroyer at speed, energy weapons charging, star field |
+| battlecruiser | Hybrid warship — fast lines but heavy guns, racing through a debris field |
+| smallCargo | Boxy utilitarian cargo shuttle, loading bay open, crates being loaded by robotic arms |
+| largeCargo | Large freighter with modular cargo pods, slow and massive, docking at a space station |
+| colonyShip | Massive colony vessel with habitat modules, generation ship scale, slow and majestic |
+| recycler | Industrial recycler ship with large scoop arrays, debris field, harvesting wrecked ships |
+| espionageProbe | Tiny stealth probe, barely visible, sleek and dark, slipping past a space station |
+| solarSatellite | Orbital solar satellite with large photovoltaic panels, planet below, sunlight glinting |
+
+### Defences
+
+| ID | Prompt Subject |
+|----|---------------|
+| rocketLauncher | Ground-based rocket battery on a planet surface, launch tubes angled skyward, exhaust trails |
+| lightLaser | Rapid-fire laser turret on a fortified platform, red-orange energy beams, targeting system |
+| heavyLaser | Heavy industrial laser cannon, massive barrel, heat vents glowing, fortified bunker |
+| gaussCannon | Railgun battery, electromagnetic coils visible, projectile accelerating in a blue flash |
+| ionCannon | Ion cannon array, electric-blue discharge crackling, atmospheric distortion |
+| plasmaTurret | Plasma turret charging, glowing sphere of superheated matter, dramatic energy arcs |
+| smallShieldDome | Translucent energy shield dome over a small base, shimmering blue, repelling a laser hit |
+| largeShieldDome | Enormous planetary shield dome, covering a city-sized area, visible from orbit |
+
+### Defences (continued)
+
+### Research Technologies
+
+| ID | Prompt Subject |
+|----|---------------|
+| energyTechnology | Energy research facility, high-voltage experiments, plasma coils, scientists observing |
+| laserTechnology | Laser research lab, precision optics, ruby laser firing into a crystal array |
+| ionTechnology | Ion drive research, blue ion exhaust in a vacuum chamber, engineers observing |
+| plasmaTechnology | Plasma containment research, swirling plasma held in magnetic fields, observatory-style lab |
+| espionageTechnology | Intelligence technology center, holographic displays of star maps, encrypted communications |
+| computerTechnology | Advanced computer core, servers and processing arrays, blue data streams |
+| weaponsTechnology | Weapons research range, scientists testing new beam weapons on armour samples |
+| shieldingTechnology | Shield generator prototype, energy barrier forming around a test structure |
+| armourTechnology | Materials lab, scientists testing new hull alloy plates with laser cutters |
+| combustionDrive | Combustion drive test stand, rocket flame, engineers in heat-resistant suits |
+| impulseDrive | Impulse drive prototype on a test rig, blue-white exhaust, space station hangar |
+| hyperspaceTechnology | Hyperspace research station, distorted space around an experimental drive, swirling wormhole |
+| hyperspaceDrive | Hyperdrive core installation, engineers working on the massive engine, ship interior |
+| astrophysicsTechnology | Space observatory, enormous telescope array pointed at a nebula, researchers inside |
+| intergalacticResearchNetwork | Massive deep-space communication array, multiple dishes, signal beams connecting star systems |
+
+### Planets
+
+| Type | Prompt |
+|------|--------|
+| hot | Volcanic alien planet from orbit, lava flows visible, scorched rock, thin atmosphere, dramatic shadow |
+| temperate | Earth-like planet from orbit, blue oceans, green-brown continents, white cloud swirls |
+| cold | Rocky grey-brown planet from orbit, thin wisps of atmosphere, cratered, desolate |
+| frozen | Ice-covered planet from orbit, white and pale blue surface, frozen methane seas, distant sun |
+
+### Page Banners
+
+| Panel | Prompt |
+|-------|--------|
+| fleet | Formation of diverse warships in deep space — fighters, cruisers, battleships — dramatic lighting, nebula backdrop |
+| defence | Planetary surface covered in defence installations — laser turrets, missile batteries, shield domes — at twilight |
+| buildings | Colony base panorama on an alien planet — mines, factories, silos, research domes — industrial scale |
+| research | Orbital research station complex, multiple modules, telescopes, labs, scientists visible through windows, planet below |
+| galaxy | Deep space panorama — star field, nebulae, a spiral galaxy in the distance, sense of vast scale |
+
+---
+
+### Commit
+
+```bash
+git add docs/plans/2026-03-07-artwork-prompts.md
+git commit -m "docs: add DALL-E image generation prompts for all artwork assets"
+```
+
+---
+
+## Notes for Codex
+
+- Do NOT generate any images. This plan is code-only (Tasks 1–10) + prompt document (Task 11).
+- `src/data/assets.ts` is a new file — it does not exist yet.
+- All panels use `<section className="panel">` as the root. Page banner goes as the **first child** of that section, before any existing content.
+- Card banners go as the **first child** of `<article className="item-card">`, before `<div className="item-header">`.
+- The `onError` handler hides the image if the `.webp` file doesn't exist — this is the graceful fallback. Do not remove it.
+- `planet.maxTemperature` is on `PlanetState`. `slot.npc.temperature` is on `NPCColony`. Both are numbers — pass directly to `getPlanetImageUrl`.
+- `public/assets/` subdirs need `.gitkeep` files so Git tracks the empty directories.
+- Run `npm run build` after Task 3 to catch any TypeScript issues early.

--- a/src/components/QueueDisplay.tsx
+++ b/src/components/QueueDisplay.tsx
@@ -4,16 +4,26 @@ import { RESEARCH } from '../data/research.ts';
 import { SHIPS } from '../data/ships.ts';
 import { useGame } from '../context/GameContext';
 import { useCountdown } from '../hooks/useCountdown';
+import { formatDuration } from '../utils/time.ts';
 import type { BuildingId, DefenceId, QueueItem, ResearchId, ShipId } from '../models/types.ts';
 
 interface QueueRowProps {
   label: string;
   subtitle: string;
   completesAt: number | null;
+  duration?: string;
   onCancel?: () => void;
 }
 
-function QueueRow({ label, subtitle, completesAt, onCancel }: QueueRowProps) {
+function getQueuedItemDuration(item: QueueItem): string {
+  const perUnitMs = item.completesAt - item.startedAt;
+  if (item.type === 'ship' || item.type === 'defence') {
+    return formatDuration((perUnitMs * (item.quantity ?? 1)) / 1000);
+  }
+  return formatDuration(perUnitMs / 1000);
+}
+
+function QueueRow({ label, subtitle, completesAt, duration, onCancel }: QueueRowProps) {
   const countdown = useCountdown(completesAt);
 
   return (
@@ -22,7 +32,9 @@ function QueueRow({ label, subtitle, completesAt, onCancel }: QueueRowProps) {
         <div className="queue-label">{label}</div>
         <div className="queue-subtitle">{subtitle}</div>
       </div>
-      {countdown && <div className="queue-time number">{countdown}</div>}
+      {(countdown || duration) && (
+        <div className="queue-time number">{countdown || duration}</div>
+      )}
       {onCancel && (
         <button type="button" className="btn btn-danger" onClick={onCancel}>
           Cancel
@@ -58,6 +70,7 @@ export function QueueDisplay() {
           label={`Building: ${BUILDINGS[item.id as BuildingId].name}`}
           subtitle={`Lv ${item.targetLevel ?? 0}${index > 0 ? ' (queued)' : ''}`}
           completesAt={index === 0 ? item.completesAt : null}
+          duration={index > 0 ? getQueuedItemDuration(item) : undefined}
           onCancel={() => cancelBuilding(index)}
         />
       ))}
@@ -68,6 +81,7 @@ export function QueueDisplay() {
           label={`Research: ${RESEARCH[item.id as ResearchId].name}`}
           subtitle={`Lv ${item.targetLevel ?? 0}${index > 0 ? ' (queued)' : ''}`}
           completesAt={index === 0 ? item.completesAt : null}
+          duration={index > 0 ? getQueuedItemDuration(item) : undefined}
           onCancel={() => cancelResearch(index)}
         />
       ))}
@@ -83,6 +97,7 @@ export function QueueDisplay() {
             label={`Shipyard: ${name}`}
             subtitle={`${progress}${index > 0 ? ' (queued)' : ''}`}
             completesAt={index === 0 ? item.completesAt : null}
+            duration={index > 0 ? getQueuedItemDuration(item) : undefined}
             onCancel={() => cancelShipyard(index)}
           />
         );

--- a/src/components/__tests__/QueueDisplay.test.tsx
+++ b/src/components/__tests__/QueueDisplay.test.tsx
@@ -101,6 +101,68 @@ describe('QueueDisplay', () => {
     expect(cancelButtons).toHaveLength(2);
   });
 
+  it('shows duration for queued (non-active) building items', () => {
+    const now = Date.now();
+    const oneHourMs = 3600 * 1000;
+
+    renderWithGame(<QueueDisplay />, {
+      gameState: {
+        planet: {
+          buildingQueue: [
+            {
+              type: 'building',
+              id: 'metalMine',
+              targetLevel: 2,
+              startedAt: now,
+              completesAt: now + oneHourMs,
+            },
+            {
+              type: 'building',
+              id: 'metalMine',
+              targetLevel: 3,
+              startedAt: now + oneHourMs,
+              completesAt: now + 3 * oneHourMs,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(screen.getByText('2h')).toBeInTheDocument();
+  });
+
+  it('shows duration for queued shipyard batches as total batch time', () => {
+    const now = Date.now();
+    const perUnitMs = 30 * 60 * 1000;
+
+    renderWithGame(<QueueDisplay />, {
+      gameState: {
+        planet: {
+          shipyardQueue: [
+            {
+              type: 'ship',
+              id: 'lightFighter',
+              quantity: 1,
+              completed: 0,
+              startedAt: now,
+              completesAt: now + perUnitMs,
+            },
+            {
+              type: 'ship',
+              id: 'cruiser',
+              quantity: 4,
+              completed: 0,
+              startedAt: now + perUnitMs,
+              completesAt: now + 2 * perUnitMs,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(screen.getByText('2h')).toBeInTheDocument();
+  });
+
   it('calls cancel actions with correct index when cancel buttons are clicked', async () => {
     const user = userEvent.setup();
     const cancelBuilding = vi.fn();

--- a/src/engine/GalaxyEngine.ts
+++ b/src/engine/GalaxyEngine.ts
@@ -8,7 +8,6 @@ import { activePlanet } from './helpers.ts';
 
 const NPC_RECOVERY_MS = 48 * 3600 * 1000;
 const NPC_RESOURCE_CAP_HOURS = 48;
-const NPC_BASE_POOL = { metal: 50_000, crystal: 30_000, deuterium: 10_000 };
 
 const NPC_NAME_PREFIXES = [
   'Zorgon',

--- a/src/engine/GalaxyEngine.ts
+++ b/src/engine/GalaxyEngine.ts
@@ -456,42 +456,32 @@ export function getNPCResources(
     crystal: 0,
     deuterium: 0,
   };
-  const tierFloor = colony.tier * colony.tier;
 
   return {
     metal: Math.max(
-      NPC_BASE_POOL.metal * tierFloor,
-      Math.max(
-        0,
-        Math.floor(
-          Math.min(
-            stockpileCap.metal,
-            baseline.metal + production.metalPerHour * elapsedHours,
-          ),
+      0,
+      Math.floor(
+        Math.min(
+          stockpileCap.metal,
+          baseline.metal + production.metalPerHour * elapsedHours,
         ),
       ),
     ),
     crystal: Math.max(
-      NPC_BASE_POOL.crystal * tierFloor,
-      Math.max(
-        0,
-        Math.floor(
-          Math.min(
-            stockpileCap.crystal,
-            baseline.crystal + production.crystalPerHour * elapsedHours,
-          ),
+      0,
+      Math.floor(
+        Math.min(
+          stockpileCap.crystal,
+          baseline.crystal + production.crystalPerHour * elapsedHours,
         ),
       ),
     ),
     deuterium: Math.max(
-      NPC_BASE_POOL.deuterium * tierFloor,
-      Math.max(
-        0,
-        Math.floor(
-          Math.min(
-            stockpileCap.deuterium,
-            baseline.deuterium + production.deuteriumPerHour * elapsedHours,
-          ),
+      0,
+      Math.floor(
+        Math.min(
+          stockpileCap.deuterium,
+          baseline.deuterium + production.deuteriumPerHour * elapsedHours,
         ),
       ),
     ),

--- a/src/engine/__tests__/GalaxyEngine.test.ts
+++ b/src/engine/__tests__/GalaxyEngine.test.ts
@@ -357,6 +357,21 @@ describe('GalaxyEngine', () => {
     expect(resources2.deuterium).toBeGreaterThanOrEqual(resources1.deuterium);
   });
 
+  it('getNPCResources reflects post-raid reduction (tier 10 floor bug)', () => {
+    const now = Date.now();
+    const colony = createNPCColony({
+      tier: 10,
+      lastRaidedAt: now,
+      resourcesAtLastRaid: { metal: 1_000_000, crystal: 600_000, deuterium: 200_000 },
+    });
+
+    const resources = getNPCResources(colony, now, 1);
+
+    expect(resources.metal).toBeLessThan(2_000_000);
+    expect(resources.crystal).toBeLessThan(1_500_000);
+    expect(resources.deuterium).toBeLessThan(600_000);
+  });
+
   it('getNPCResources scales production with game speed', () => {
     const now = 2_500_000_000;
     const baseline = { metal: 52_000, crystal: 32_000, deuterium: 12_000 };

--- a/src/engine/__tests__/NPCScaling.test.ts
+++ b/src/engine/__tests__/NPCScaling.test.ts
@@ -138,25 +138,19 @@ describe('catch-up upgrade mode', () => {
   });
 });
 
-describe('getNPCResources tier² floor', () => {
-  it('tier-1 NPC has at least BASE_POOL × 1 resources', () => {
+describe('getNPCResources post-raid state', () => {
+  it('respects resourcesAtLastRaid instead of snapping back to a tier floor', () => {
+    const now = Date.now();
+    const baseline = { metal: 1_000, crystal: 500, deuterium: 0 };
     const colony = {
       ...makeStateWithColony().galaxy.npcColonies[0]!,
-      tier: 1,
-      lastRaidedAt: Date.now() - 1000, // recently raided
-      resourcesAtLastRaid: { metal: 0, crystal: 0, deuterium: 0 },
+      tier: 4,
+      lastRaidedAt: now,
+      resourcesAtLastRaid: baseline,
     };
-    const resources = getNPCResources(colony, Date.now(), 1);
-    expect(resources.metal).toBeGreaterThanOrEqual(50_000);
-    expect(resources.crystal).toBeGreaterThanOrEqual(30_000);
-  });
 
-  it('tier-4 NPC floor is 16× tier-1 floor', () => {
-    const base = makeStateWithColony().galaxy.npcColonies[0]!;
-    const colony4 = { ...base, tier: 4, lastRaidedAt: Date.now() - 1000, resourcesAtLastRaid: { metal: 0, crystal: 0, deuterium: 0 } };
-    const colony1 = { ...base, tier: 1, lastRaidedAt: Date.now() - 1000, resourcesAtLastRaid: { metal: 0, crystal: 0, deuterium: 0 } };
-    const r4 = getNPCResources(colony4, Date.now(), 1);
-    const r1 = getNPCResources(colony1, Date.now(), 1);
-    expect(r4.metal).toBeGreaterThanOrEqual(r1.metal * 16 * 0.9); // tier² scaling with 10% tolerance
+    const resources = getNPCResources(colony, now, 1);
+
+    expect(resources).toEqual(baseline);
   });
 });

--- a/src/panels/BuildingsPanel.tsx
+++ b/src/panels/BuildingsPanel.tsx
@@ -109,7 +109,8 @@ export function BuildingsPanel() {
               (buildingId) => {
                 const definition = BUILDINGS[buildingId];
                 const currentLevel = planet.buildings[buildingId];
-                const nextLevel = currentLevel + 1;
+                const queuedCount = planet.buildingQueue.filter((q) => q.id === buildingId).length;
+                const nextLevel = currentLevel + queuedCount + 1;
                 const cost = buildingCostAtLevel(
                   definition.baseCost,
                   definition.costMultiplier,

--- a/src/panels/DefencePanel.tsx
+++ b/src/panels/DefencePanel.tsx
@@ -128,22 +128,44 @@ export function DefencePanel() {
 
               <div className="item-meta">
                 <span className="label">Batch Quantity</span>
-                <input
-                  className="input quantity-input number"
-                  type="number"
-                  min={1}
-                  step={1}
-                  max={remainingMax ?? undefined}
-                  value={quantityInput}
-                  disabled={maxReached}
-                  onChange={(event) => {
-                    const nextValue = event.target.value;
-                    setQuantities((current) => ({
-                      ...current,
-                      [defenceId]: nextValue,
-                    }));
-                  }}
-                />
+                <div className="qty-input-group">
+                  <input
+                    className="input quantity-input number"
+                    type="number"
+                    min={1}
+                    step={1}
+                    max={remainingMax ?? undefined}
+                    value={quantityInput}
+                    disabled={maxReached}
+                    onChange={(event) => {
+                      const nextValue = event.target.value;
+                      setQuantities((current) => ({
+                        ...current,
+                        [defenceId]: nextValue,
+                      }));
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-sm"
+                    disabled={maxReached}
+                    onClick={() => {
+                      const { metal, crystal, deuterium } = planet.resources;
+                      const { cost } = definition;
+                      const limits: number[] = [];
+                      if (cost.metal > 0) limits.push(Math.floor(metal / cost.metal));
+                      if (cost.crystal > 0) limits.push(Math.floor(crystal / cost.crystal));
+                      if (cost.deuterium > 0) limits.push(Math.floor(deuterium / cost.deuterium));
+                      let max = limits.length > 0 ? Math.max(0, Math.min(...limits)) : 0;
+                      if (remainingMax !== null) {
+                        max = Math.min(max, remainingMax);
+                      }
+                      setQuantities((current) => ({ ...current, [defenceId]: String(max) }));
+                    }}
+                  >
+                    Max
+                  </button>
+                </div>
               </div>
 
               <div className="item-meta">

--- a/src/panels/FleetPanel.tsx
+++ b/src/panels/FleetPanel.tsx
@@ -12,7 +12,7 @@ import {
   calcMaxFleetSlots,
   calcTravelSeconds,
 } from '../engine/FleetEngine.ts';
-import { getNPCResources } from '../engine/GalaxyEngine.ts';
+
 import { useCountdown } from '../hooks/useCountdown.ts';
 import { formatNumber } from '../utils/format.ts';
 import { formatDuration } from '../utils/time.ts';
@@ -536,9 +536,9 @@ export function FleetPanel() {
       )
       .sort((a, b) => b.timestamp - a.timestamp)[0];
 
-    const resources = reportWithResources?.resources
-      ?? getNPCResources(colony, currentTime, gameState.settings.gameSpeed);
+    if (!reportWithResources?.resources) return null;
 
+    const resources = reportWithResources.resources;
     const lootable = Math.floor(
       (resources.metal + resources.crystal + resources.deuterium) * 0.5,
     );
@@ -557,15 +557,12 @@ export function FleetPanel() {
       additionalSmall,
       availableLarge,
       availableSmall,
-      fromReport: reportWithResources !== undefined,
     };
   }, [
     cargoCapacity,
-    currentTime,
     espionageReports,
     fleetTarget,
     gameState.galaxy.npcColonies,
-    gameState.settings.gameSpeed,
     missionType,
     sourcePlanet.ships,
   ]);
@@ -580,6 +577,15 @@ export function FleetPanel() {
     !slotsFull &&
     !insufficientFuel &&
     !invalidTransportCargo;
+
+  const remainingLarge = cargoInfo
+    ? Math.max(0, cargoInfo.availableLarge - (selectedShips.largeCargo ?? 0))
+    : 0;
+  const remainingSmall = cargoInfo
+    ? Math.max(0, cargoInfo.availableSmall - (selectedShips.smallCargo ?? 0))
+    : 0;
+  const cargoAddableLarge = cargoInfo ? Math.min(cargoInfo.additionalLarge, remainingLarge) : 0;
+  const cargoAddableSmall = cargoInfo ? Math.min(cargoInfo.additionalSmall, remainingSmall) : 0;
 
   return (
     <section className="panel">
@@ -813,7 +819,7 @@ export function FleetPanel() {
             <div className="fleet-cargo-helper">
               <div className="fleet-cargo-header">
                 <strong>Cargo needed</strong>
-                <span className="hint">{cargoInfo.fromReport ? 'from spy report' : 'estimated'}</span>
+                <span className="hint">from spy report</span>
               </div>
               <p className="stat-line">
                 <span className="label">Lootable</span>
@@ -824,40 +830,38 @@ export function FleetPanel() {
                 <span className="number">{formatNumber(cargoCapacity)}</span>
               </p>
               <div className="fleet-cargo-buttons">
-                {cargoInfo.additionalLarge > 0 && (
+                {cargoAddableLarge > 0 && (
                   <button
                     type="button"
                     className="btn btn-sm"
-                    disabled={cargoInfo.availableLarge < cargoInfo.additionalLarge}
                     onClick={() => {
                       setSelectedShips((current) => ({
                         ...current,
                         largeCargo: Math.min(
                           cargoInfo.availableLarge,
-                          (current.largeCargo ?? 0) + cargoInfo.additionalLarge,
+                          (current.largeCargo ?? 0) + cargoAddableLarge,
                         ),
                       }));
                     }}
                   >
-                    + {cargoInfo.additionalLarge} Large Cargo
+                    + {cargoAddableLarge} Large Cargo
                   </button>
                 )}
-                {cargoInfo.additionalSmall > 0 && (
+                {cargoAddableSmall > 0 && (
                   <button
                     type="button"
                     className="btn btn-sm"
-                    disabled={cargoInfo.availableSmall < cargoInfo.additionalSmall}
                     onClick={() => {
                       setSelectedShips((current) => ({
                         ...current,
                         smallCargo: Math.min(
                           cargoInfo.availableSmall,
-                          (current.smallCargo ?? 0) + cargoInfo.additionalSmall,
+                          (current.smallCargo ?? 0) + cargoAddableSmall,
                         ),
                       }));
                     }}
                   >
-                    + {cargoInfo.additionalSmall} Small Cargo
+                    + {cargoAddableSmall} Small Cargo
                   </button>
                 )}
               </div>

--- a/src/panels/FleetPanel.tsx
+++ b/src/panels/FleetPanel.tsx
@@ -12,6 +12,7 @@ import {
   calcMaxFleetSlots,
   calcTravelSeconds,
 } from '../engine/FleetEngine.ts';
+import { getNPCResources } from '../engine/GalaxyEngine.ts';
 import { useCountdown } from '../hooks/useCountdown.ts';
 import { formatNumber } from '../utils/format.ts';
 import { formatDuration } from '../utils/time.ts';
@@ -513,6 +514,62 @@ export function FleetPanel() {
     return buildCombatEstimate(ratio);
   }, [gameState.research.weaponsTechnology, latestCombatIntel, selectedShipCount, selectedShips]);
 
+  const cargoInfo = useMemo(() => {
+    if (missionType !== 'attack' || !fleetTarget) return null;
+
+    const colony = gameState.galaxy.npcColonies.find(
+      (c) =>
+        c.coordinates.galaxy === fleetTarget.galaxy &&
+        c.coordinates.system === fleetTarget.system &&
+        c.coordinates.slot === fleetTarget.slot,
+    );
+    if (!colony) return null;
+
+    const reportWithResources = espionageReports
+      .filter(
+        (report) =>
+          report.targetCoordinates.galaxy === fleetTarget.galaxy &&
+          report.targetCoordinates.system === fleetTarget.system &&
+          report.targetCoordinates.slot === fleetTarget.slot &&
+          report.detected === false &&
+          report.resources !== undefined,
+      )
+      .sort((a, b) => b.timestamp - a.timestamp)[0];
+
+    const resources = reportWithResources?.resources
+      ?? getNPCResources(colony, currentTime, gameState.settings.gameSpeed);
+
+    const lootable = Math.floor(
+      (resources.metal + resources.crystal + resources.deuterium) * 0.5,
+    );
+
+    const largeCargoCap = SHIPS.largeCargo.cargoCapacity;
+    const smallCargoCap = SHIPS.smallCargo.cargoCapacity;
+    const availableLarge = sourcePlanet.ships.largeCargo ?? 0;
+    const availableSmall = sourcePlanet.ships.smallCargo ?? 0;
+    const deficit = Math.max(0, lootable - cargoCapacity);
+    const additionalLarge = Math.ceil(deficit / largeCargoCap);
+    const additionalSmall = Math.ceil(deficit / smallCargoCap);
+
+    return {
+      lootable,
+      additionalLarge,
+      additionalSmall,
+      availableLarge,
+      availableSmall,
+      fromReport: reportWithResources !== undefined,
+    };
+  }, [
+    cargoCapacity,
+    currentTime,
+    espionageReports,
+    fleetTarget,
+    gameState.galaxy.npcColonies,
+    gameState.settings.gameSpeed,
+    missionType,
+    sourcePlanet.ships,
+  ]);
+
   const insufficientFuel = sourcePlanet.resources.deuterium < dispatchPreview.fuelCost;
   const invalidTransportCargo =
     missionType === 'transport' &&
@@ -749,6 +806,61 @@ export function FleetPanel() {
               <p className="fleet-combat-title">{combatEstimate.title}</p>
               <p className="hint">{combatEstimate.message}</p>
               <p className="hint">Approximate only, based on latest espionage report.</p>
+            </div>
+          )}
+
+          {cargoInfo && missionType === 'attack' && (
+            <div className="fleet-cargo-helper">
+              <div className="fleet-cargo-header">
+                <strong>Cargo needed</strong>
+                <span className="hint">{cargoInfo.fromReport ? 'from spy report' : 'estimated'}</span>
+              </div>
+              <p className="stat-line">
+                <span className="label">Lootable</span>
+                <span className="number">~{formatNumber(cargoInfo.lootable)}</span>
+              </p>
+              <p className="stat-line">
+                <span className="label">Fleet cargo capacity</span>
+                <span className="number">{formatNumber(cargoCapacity)}</span>
+              </p>
+              <div className="fleet-cargo-buttons">
+                {cargoInfo.additionalLarge > 0 && (
+                  <button
+                    type="button"
+                    className="btn btn-sm"
+                    disabled={cargoInfo.availableLarge < cargoInfo.additionalLarge}
+                    onClick={() => {
+                      setSelectedShips((current) => ({
+                        ...current,
+                        largeCargo: Math.min(
+                          cargoInfo.availableLarge,
+                          (current.largeCargo ?? 0) + cargoInfo.additionalLarge,
+                        ),
+                      }));
+                    }}
+                  >
+                    + {cargoInfo.additionalLarge} Large Cargo
+                  </button>
+                )}
+                {cargoInfo.additionalSmall > 0 && (
+                  <button
+                    type="button"
+                    className="btn btn-sm"
+                    disabled={cargoInfo.availableSmall < cargoInfo.additionalSmall}
+                    onClick={() => {
+                      setSelectedShips((current) => ({
+                        ...current,
+                        smallCargo: Math.min(
+                          cargoInfo.availableSmall,
+                          (current.smallCargo ?? 0) + cargoInfo.additionalSmall,
+                        ),
+                      }));
+                    }}
+                  >
+                    + {cargoInfo.additionalSmall} Small Cargo
+                  </button>
+                )}
+              </div>
             </div>
           )}
 

--- a/src/panels/ResearchPanel.tsx
+++ b/src/panels/ResearchPanel.tsx
@@ -67,7 +67,8 @@ export function ResearchPanel() {
         {RESEARCH_ORDER.map((researchId) => {
           const definition = RESEARCH[researchId];
           const currentLevel = gameState.research[researchId];
-          const nextLevel = currentLevel + 1;
+          const queuedCount = gameState.researchQueue.filter((q) => q.id === researchId).length;
+          const nextLevel = currentLevel + queuedCount + 1;
           const cost = researchCostAtLevel(
             definition.baseCost,
             definition.costMultiplier,

--- a/src/panels/ShipyardPanel.tsx
+++ b/src/panels/ShipyardPanel.tsx
@@ -129,20 +129,38 @@ export function ShipyardPanel() {
 
               <div className="item-meta">
                 <span className="label">Batch Quantity</span>
-                <input
-                  className="input quantity-input number"
-                  type="number"
-                  min={1}
-                  step={1}
-                  value={quantityInput}
-                  onChange={(event) => {
-                    const nextValue = event.target.value;
-                    setQuantities((current) => ({
-                      ...current,
-                      [shipId]: nextValue,
-                    }));
-                  }}
-                />
+                <div className="qty-input-group">
+                  <input
+                    className="input quantity-input number"
+                    type="number"
+                    min={1}
+                    step={1}
+                    value={quantityInput}
+                    onChange={(event) => {
+                      const nextValue = event.target.value;
+                      setQuantities((current) => ({
+                        ...current,
+                        [shipId]: nextValue,
+                      }));
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-sm"
+                    onClick={() => {
+                      const { metal, crystal, deuterium } = planet.resources;
+                      const { cost } = definition;
+                      const limits: number[] = [];
+                      if (cost.metal > 0) limits.push(Math.floor(metal / cost.metal));
+                      if (cost.crystal > 0) limits.push(Math.floor(crystal / cost.crystal));
+                      if (cost.deuterium > 0) limits.push(Math.floor(deuterium / cost.deuterium));
+                      const max = limits.length > 0 ? Math.max(0, Math.min(...limits)) : 0;
+                      setQuantities((current) => ({ ...current, [shipId]: String(max) }));
+                    }}
+                  >
+                    Max
+                  </button>
+                </div>
               </div>
 
               <div className="item-meta">

--- a/src/panels/__tests__/BuildingsPanel.test.tsx
+++ b/src/panels/__tests__/BuildingsPanel.test.tsx
@@ -84,6 +84,35 @@ describe('BuildingsPanel', () => {
     ).not.toBeDisabled();
   });
 
+  it('upgrade button shows future level accounting for items already in queue', () => {
+    renderWithGame(<BuildingsPanel />, {
+      gameState: {
+        planet: {
+          buildings: { metalMine: 5 },
+          buildingQueue: [
+            {
+              type: 'building',
+              id: 'metalMine',
+              targetLevel: 6,
+              startedAt: Date.now(),
+              completesAt: Date.now() + 60_000,
+            },
+            {
+              type: 'building',
+              id: 'metalMine',
+              targetLevel: 7,
+              startedAt: Date.now() + 60_000,
+              completesAt: Date.now() + 120_000,
+            },
+          ],
+          resources: { metal: 10_000_000, crystal: 10_000_000, deuterium: 10_000_000 },
+        },
+      },
+    });
+
+    expect(screen.getByRole('button', { name: 'Queue Lv 8' })).toBeInTheDocument();
+  });
+
   it('calls upgradeBuilding with the correct building ID', async () => {
     const user = userEvent.setup();
     const upgradeBuilding = vi.fn(() => true);

--- a/src/panels/__tests__/DefencePanel.test.tsx
+++ b/src/panels/__tests__/DefencePanel.test.tsx
@@ -1,0 +1,48 @@
+import userEvent from '@testing-library/user-event';
+import { DefencePanel } from '../DefencePanel';
+import { renderWithGame, screen, within } from '../../test/test-utils';
+
+describe('DefencePanel', () => {
+  it('Max button sets quantity to max affordable count', async () => {
+    const user = userEvent.setup();
+
+    renderWithGame(<DefencePanel />, {
+      gameState: {
+        planet: {
+          buildings: { shipyard: 1 },
+          resources: { metal: 24_000, crystal: 8_000, deuterium: 0 },
+        },
+      },
+    });
+
+    const heading = screen.getByRole('heading', { name: 'Rocket Launcher', level: 3 });
+    const card = heading.closest('article');
+    expect(card).not.toBeNull();
+
+    await user.click(within(card as HTMLElement).getByRole('button', { name: 'Max' }));
+
+    expect(within(card as HTMLElement).getByRole('spinbutton')).toHaveValue(12);
+  });
+
+  it('Max button caps at remainingMax for limited defences', async () => {
+    const user = userEvent.setup();
+
+    renderWithGame(<DefencePanel />, {
+      gameState: {
+        planet: {
+          buildings: { shipyard: 2 },
+          resources: { metal: 10_000_000, crystal: 10_000_000, deuterium: 10_000_000 },
+        },
+        research: { shieldingTechnology: 2 },
+      },
+    });
+
+    const heading = screen.getByRole('heading', { name: 'Small Shield Dome', level: 3 });
+    const card = heading.closest('article');
+    expect(card).not.toBeNull();
+
+    await user.click(within(card as HTMLElement).getByRole('button', { name: 'Max' }));
+
+    expect(within(card as HTMLElement).getByRole('spinbutton')).toHaveValue(1);
+  });
+});

--- a/src/panels/__tests__/FleetPanel.test.tsx
+++ b/src/panels/__tests__/FleetPanel.test.tsx
@@ -300,4 +300,71 @@ describe('FleetPanel', () => {
       3,
     );
   });
+
+  it('shows cargo capacity helper with + cargo buttons when attacking NPC with known resources', async () => {
+    const user = userEvent.setup();
+    const now = Date.now();
+
+    renderWithGame(<FleetPanel />, {
+      gameState: {
+        galaxy: {
+          seed: 1,
+          npcColonies: [
+            {
+              coordinates: { galaxy: 1, system: 2, slot: 4 },
+              name: 'Target Base',
+              temperature: 25,
+              tier: 5,
+              specialty: 'balanced',
+              maxTier: 8,
+              initialUpgradeIntervalMs: 10_800_000,
+              currentUpgradeIntervalMs: 10_800_000,
+              targetTier: 5,
+              catchUpUpgradeIntervalMs: 2_700_000,
+              catchUpProgressTicks: 0,
+              lastUpgradeAt: 0,
+              upgradeTickCount: 0,
+              raidCount: 0,
+              recentRaidTimestamps: [],
+              abandonedAt: undefined,
+              buildings: {},
+              baseDefences: {},
+              baseShips: {},
+              currentDefences: {},
+              currentShips: {},
+              lastRaidedAt: 0,
+              resourcesAtLastRaid: { metal: 0, crystal: 0, deuterium: 0 },
+            },
+          ],
+        },
+        espionageReports: [
+          {
+            id: 'report_1',
+            timestamp: now - 1000,
+            targetCoordinates: { galaxy: 1, system: 2, slot: 4 },
+            targetName: 'Target Base',
+            sourcePlanetIndex: 0,
+            probesSent: 1,
+            probesLost: 0,
+            detected: false,
+            detectionChance: 0,
+            read: false,
+            resources: { metal: 200_000, crystal: 100_000, deuterium: 50_000 },
+          },
+        ],
+        planet: {
+          ships: { largeCargo: 10, smallCargo: 5 },
+          resources: { deuterium: 50_000 },
+        },
+      },
+      actions: { fleetTarget: { galaxy: 1, system: 2, slot: 4 } },
+    });
+
+    expect(screen.getByText(/Lootable/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /\+ 7 Large Cargo/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /\+ 7 Large Cargo/i }));
+
+    expect(screen.getAllByText(/175,000/)).toHaveLength(2);
+  });
 });

--- a/src/panels/__tests__/ResearchPanel.test.tsx
+++ b/src/panels/__tests__/ResearchPanel.test.tsx
@@ -86,6 +86,30 @@ describe('ResearchPanel', () => {
     ).not.toBeDisabled();
   });
 
+  it('research button shows future level accounting for items already in queue', () => {
+    renderWithGame(<ResearchPanel />, {
+      gameState: {
+        research: { energyTechnology: 3 },
+        researchQueue: [
+          {
+            type: 'research',
+            id: 'energyTechnology',
+            targetLevel: 4,
+            sourcePlanetIndex: 0,
+            startedAt: Date.now(),
+            completesAt: Date.now() + 60_000,
+          },
+        ],
+        planet: {
+          buildings: { researchLab: 1 },
+          resources: { metal: 10_000_000, crystal: 10_000_000, deuterium: 10_000_000 },
+        },
+      },
+    });
+
+    expect(screen.getByRole('button', { name: 'Queue Lv 5' })).toBeInTheDocument();
+  });
+
   it('calls startResearchAction with the correct research ID', async () => {
     const user = userEvent.setup();
     const startResearchAction = vi.fn(() => true);

--- a/src/panels/__tests__/ShipyardPanel.test.tsx
+++ b/src/panels/__tests__/ShipyardPanel.test.tsx
@@ -93,6 +93,27 @@ describe('ShipyardPanel', () => {
     expect(within(lightFighterCard).getByText('C 3,000')).toBeInTheDocument();
   });
 
+  it('Max button sets quantity to max affordable count', async () => {
+    const user = userEvent.setup();
+
+    renderWithGame(<ShipyardPanel />, {
+      gameState: {
+        planet: {
+          buildings: { shipyard: 2 },
+          resources: { metal: 6000, crystal: 2000, deuterium: 0 },
+        },
+        research: { combustionDrive: 2 },
+      },
+    });
+
+    const card = screen.getByRole('heading', { name: 'Small Cargo', level: 3 }).closest('article');
+    expect(card).not.toBeNull();
+
+    await user.click(within(card as HTMLElement).getByRole('button', { name: 'Max' }));
+
+    expect(within(card as HTMLElement).getByRole('spinbutton')).toHaveValue(1);
+  });
+
   it('calls buildShips with ship ID and quantity', async () => {
     const user = userEvent.setup();
     const buildShips = vi.fn(() => true);

--- a/src/styles.css
+++ b/src/styles.css
@@ -451,6 +451,12 @@ body {
   max-width: 92px;
 }
 
+.qty-input-group {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .textarea {
   resize: vertical;
   min-height: 110px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -653,6 +653,28 @@ body {
   background: rgba(34, 197, 94, 0.1);
 }
 
+.fleet-cargo-helper {
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  padding: 0.6rem 0.8rem;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.fleet-cargo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.4rem;
+}
+
+.fleet-cargo-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+  flex-wrap: wrap;
+}
+
 .fleet-dispatch-footer {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

This PR delivers a set of UX improvements, a significant engine bugfix, and lays the groundwork for the artwork system.

## Engine Bugfix

### NPC Resource Floor — Raiding Had No Effect
**Root cause:** `getNPCResources()` in `GalaxyEngine.ts` applied a `Math.max(NPC_BASE_POOL.* × tier², ...)` floor to all returned values. For a tier 10 NPC this floor equalled 5,000,000 metal — the same as the stockpile cap. No matter how much the player looted, the next call to `getNPCResources` returned the same pre-raid amount, making raiding effectively useless at high tiers.

**Fix:** Removed the outer `Math.max(NPC_BASE_POOL.* × tier², ...)` wrapper. Resources now correctly reflect `colony.resourcesAtLastRaid` after a raid, recovering naturally via continuous production. Also removed the now-unused `NPC_BASE_POOL` constant and updated `NPCScaling.test.ts` to match the corrected behaviour.

## UI Improvements

### Max Button — Shipyard & Defence Panels
Adds a **Max** button next to the quantity input on each ship and defence card. Clicking it sets the quantity to the maximum affordable given current resources. For capped defences (e.g. Shield Domes), it respects the remaining build limit.

### Queue Item Durations — QueueDisplay
Non-active queued items (buildings, research, ships) now show their build duration (e.g. `2h`, `45m`) instead of a blank space. For ship/defence batches the duration shown is the total batch time (`perUnit × quantity`).

### Level-Aware Upgrade Buttons — Buildings & Research
The upgrade button label and cost now account for items already in the queue. With Metal Mine at level 5 and two items queued, the button shows **Queue Lv 8** and displays the cost for level 8 — matching the actual next level that will be queued.

### Fleet Cargo Capacity Helper
On attack missions targeting an NPC with a known spy report, a **Cargo needed** panel appears showing:
- Estimated lootable resources (50% of spy report total)
- Current fleet cargo capacity
- **+ N Large Cargo** / **+ N Small Cargo** buttons that add only the deficit needed to cover the loot (accounts for ships already selected)

## Artwork System (Docs Only)

Two planning documents committed:
- `docs/plans/2026-03-07-artwork-design.md` — design spec for card banners, page banners, and planet visuals
- `docs/plans/2026-03-07-artwork-implementation.md` — full implementation plan including DALL-E 3 prompts for all ~57 images

No artwork code is included in this PR — that follows in a subsequent branch once images are generated.

## Test Coverage

- 337 tests across 34 files — all passing
- New test files: `DefencePanel.test.tsx`, `QueueDisplay.test.tsx`, `assets.test.ts` (artwork, next PR)
- Updated: `NPCScaling.test.ts`, `GalaxyEngine.test.ts`, `BuildingsPanel.test.tsx`, `ResearchPanel.test.tsx`, `ShipyardPanel.test.tsx`, `FleetPanel.test.tsx`

## Commits

```
fix(engine): remove NPC resource tier² floor that prevented loot from reducing stockpile
feat(shipyard): add Max button to set quantity to max affordable
feat(defence): add Max button to set quantity to max affordable
feat(queue): show build duration for queued items
feat(buildings): upgrade button reflects queue depth for level and cost
feat(research): research button reflects queue depth for level and cost
feat(fleet): add cargo capacity helper with required ship buttons for attack missions
docs: artwork system design — card banners, page banners, planet visuals
docs: artwork system implementation plan with DALL-E prompts
fix(engine): remove unused NPC_BASE_POOL constant after tierFloor removal
```